### PR TITLE
Update plugin_init.rb

### DIFF
--- a/backend/plugin_init.rb
+++ b/backend/plugin_init.rb
@@ -1,26 +1,17 @@
-# Due to issues with the serializer, resources with refs in mixed content will fail because of a spurious
-# application of the xlink namespace to attributes (specifically, @target)
-#
-# Once this PR is merged and a release with it adopted, this code can be removed
-# https://github.com/archivesspace/archivesspace/pull/2353
-class ReplacementSerializer < EADSerializer
-  serializer_for :ead
-  def add_xlink_prefix(content)
-    %w{ actuate arcrole from href role show title to}.each do |xa|
-      content.gsub!(/ #{xa}=/) {|match| " xlink:#{match.strip}"} if content =~ / #{xa}=/
-    end
-    content
+# Override for the uris until https://archivesspace.atlassian.net/browse/ANW-1843 is implemented
+
+class EADSerializer < ASpaceExport::Serializer
+
+  def serialize_aspace_uri(data, xml)
+    # Do nothing
   end
+
 end
 
-# Add this method to allow direct manipulation of serializers
-module ASpaceExport
-  def self.serializers
-    @@serializers
-  end
-end
+class EAD3Serializer < EADSerializer
 
-ASpaceExport.serializers.delete(EADSerializer)
-# Note: serializers are searched in registration order,
-# add to front in case EADSerializer is re-registered somehow
-ASpaceExport.serializers.insert(0, ReplacementSerializer)
+  def serialize_aspace_uri(data, xml)
+    # Do nothing
+  end
+
+end


### PR DESCRIPTION
Removed the an older EAD Override (since that code is now in core) and put in the new override needed to suppress URI introduced in 3.4.1 until code is merged to do that in core