### PR TITLE
Update as-ead-pdf.xsl

### DIFF
--- a/as-ead-pdf.xsl
+++ b/as-ead-pdf.xsl
@@ -1548,7 +1548,7 @@
     <xsl:template match="ead:did" mode="dsc">
         <fo:block margin-bottom="0">
             <!-- HARVARD CUSTOMIZATION: Display the unit id -->
-            <xsl:if test="(string-length(ead:unitid[not(@type='aspace_uri')][0]) &gt; 0)">
+            <xsl:if test="(string-length(ead:unitid[not(@type='aspace_uri')][1]) &gt; 0)">
                 <fo:inline font-style="italic">
                     <xsl:value-of select="ead:unitid[not(@type='aspace_uri')]"/>
                     <xsl:text>: </xsl:text>


### PR DESCRIPTION
This fixes the missing component unique ids on the staff side when I test locally.

To test, set your local to use this (and make sure to do the manual copy of the correct file in the directions when the container is up) and then export a pdf from staff side. you'll see the component unique ids next to titles in the collection inventory area